### PR TITLE
Url decode fields from credentials

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/user"
 	"strings"
+	"net/url"
 )
 
 const (
@@ -180,20 +181,32 @@ func parseCredential(line string) *credential {
 		// malformed line, ignore
 		return nil
 	}
-	username := credFields[0]
-	password := credFields[1]
-
+	username,err := url.QueryUnescape(credFields[0])
+    	if err != nil {
+        	return nil
+	}
+	password,err := url.QueryUnescape(credFields[1])
+    	if err != nil {
+        	return nil
+	}
+	
 	hostAndPath := fields[1]
 	hostFields := strings.SplitN(hostAndPath, "/", 2)
 	if len(hostFields) != 1 && len(hostFields) != 2 {
 		// malformed line, ignore
 		return nil
 	}
-	host := hostFields[0]
-
+	host,err := url.QueryUnescape(hostFields[0])
+	if err != nil {
+        	return nil
+	}
+	
 	var path string
 	if len(hostFields) == 2 {
-		path = hostFields[1]
+		path,err = url.QueryUnescape(hostFields[1])
+		if err != nil {
+        		return nil
+		}
 	}
 
 	return &credential{


### PR DESCRIPTION
Data store in .git-credentials are url encode / escape : https://github.com/git/git/blob/406f326d271e0bacecdb00425422c5fa3f314930/builtin/credential-store.c#L102

And data are decoded when reading before use it : https://github.com/git/git/blob/406f326d271e0bacecdb00425422c5fa3f314930/credential.c#L617

username, password, host and path are encoded and need to be decoded. 

Use module "net/url" and "url.QueryUnescape"