### PR TITLE
Ignore comment in credentials

### DIFF
--- a/main.go
+++ b/main.go
@@ -234,11 +234,18 @@ func getCredential(req *credential, credFile string) *credential {
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
 		line := scanner.Text()
+		
+		if strings.HasPrefix(strings.TrimSpace(line), "#") || strings.HasPrefix(strings.TrimSpace(line), "//") {
+			log.Printf("ignore comment : %s", line)
+			continue
+		}
+
 		cred := parseCredential(line)
 		if cred == nil {
 			log.Printf("err malformed credential line: %s", line)
 			continue
 		}
+		
 		if cred.match(req) {
 			return cred
 		}


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Skip comment lines in credential files during parsing

- Support both hash (#) and double-slash (//) comment styles

- Add logging for ignored comment lines


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Read credential file line"] --> B{"Is line a comment?"}
  B -->|Yes| C["Log and skip line"]
  B -->|No| D["Parse credential"]
  C --> A
  D --> E["Match credential"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.go</strong><dd><code>Add comment filtering to credential parser</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

main.go

<ul><li>Added comment detection logic to skip lines starting with '#' or '//'<br> <li> Implemented logging for ignored comment lines<br> <li> Improved credential file parsing to handle comments gracefully<br> <li> Maintains existing credential matching behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/ttys3/git-credential-readonly/pull/3/files#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

