### PR TITLE
Improved Usernames / Organization / Groups Path Matching in credentials

### DIFF
--- a/main.go
+++ b/main.go
@@ -100,19 +100,9 @@ func (c *credential) match(req *credential) bool {
 	}
 
 	if req.path != "" {
-		// get username or org from repo path like `username-or-org/reponame.git`
-		reqOrg, _, hasSep := strings.Cut(req.path, "/")
-		if hasSep && reqOrg != "" {
-			matchReqPath := strings.TrimRight(reqOrg, "/")
-			matchConfigPath := strings.TrimRight(c.path, "/")
-			match = match && matchReqPath == matchConfigPath
-			log.Printf("match path by username or org: req.path=%v,config.path=%v,result=%v",
-				matchReqPath, matchConfigPath, match)
-		} else {
-			match = match && c.path == req.path
-			log.Printf("match path: req.path=%v,other.path=%v,result=%v",
-				c.path, req.path, match)
-		}
+		match = match && strings.HasPrefix(req.path, c.path)
+		log.Printf("match path by username or org: req.path=%v,config.path=%v,result=%v",
+				req.path, c.path, match)
 	}
 	return match
 }

--- a/main.go
+++ b/main.go
@@ -234,11 +234,18 @@ func getCredential(req *credential, credFile string) *credential {
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
 		line := scanner.Text()
+		
+		if strings.HasPrefix(strings.TrimSpace(line), "#") || strings.HasPrefix(strings.TrimSpace(line), "//") {
+			log.Printf("ignore comment : %s", line)
+			continue
+		}
+
 		cred := parseCredential(line)
 		if cred == nil {
 			log.Printf("err malformed credential line: %s", line)
 			continue
 		}
+		
 		if cred.match(req) {
 			return cred
 		}


### PR DESCRIPTION
### **User description**
The old version only supported host verification. When combined with useHttpPath, it could only check a single-level path for usernames, organizations, or groups, not the full path.
If the first line matched the host or the first-level path, those credentials were returned, even if a later line specified a more precise path.

Example:
https://USERNAME:TOKEN1@gitlab.com/group/subgroup1/project.git
https://USERNAME:TOKEN2@gitlab.com/group/subgroup2/project2.git
https://USERNAME:TOKEN3@gitlab.com/group/subgroup2/
https://USERNAME:TOKEN4@gitlab.com/group/

For the repository:
https://USERNAME:TOKEN2@gitlab.com/group/subgroup2/project2.git

    Without useHttpPath: Only the host, protocol, and HTTP username (if specified) are checked. It returns TOKEN1.
    With useHttpPath (old version), only the first-level path was checked, even though the rest of the path did not match. In this case, it’s the same as above, so it returns TOKEN1.

Now, The system checks if the path configured in the credentials is the beginning of the requested path.

For the same repository:
https://USERNAME:TOKEN2@gitlab.com/group/subgroup2/project2.git

    Without useHttpPath: Behavior remains unchanged (returns TOKEN1).
    With useHttpPath (new version): It can now match the full path or a partial path, regardless of the number of username/organization/group levels. Since the full path of the first line doesn’t match the request, it continues to the second line, which does match. It returns TOKEN2.

Notes:
    The third line provides global credentials for other projects under /group/subgroup2/.
    The fourth line provides global credentials for other projects under /group/.

Important:
    The order of lines in the credentials file matters. More specific paths should be listed before broader ones.

I hope this doesn’t alter the originally intended behavior.

If the pull request is accepted, I think we’ll need to update the end of the documentation.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Improved path matching to support full paths instead of single-level

- Now checks if configured path is prefix of requested path

- Added support for ignoring comments in credentials file

- Simplified path matching logic with `strings.HasPrefix`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Old Path Matching"] -->|"Single-level only"| B["Limited accuracy"]
  C["New Path Matching"] -->|"Full path prefix check"| D["Better accuracy"]
  E["Comment Support"] -->|"Skip # and //"| F["Cleaner config files"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.go</strong><dd><code>Simplify path matching and add comment filtering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

main.go

<ul><li>Replaced single-level path matching with <code>strings.HasPrefix</code> for full <br>path comparison<br> <li> Simplified path matching logic by removing <code>strings.Cut</code> and separate <br>handling branches<br> <li> Added comment filtering to skip lines starting with <code>#</code> or <code>//</code> in <br>credentials file<br> <li> Improved logging to show actual paths being compared</ul>


</details>


  </td>
  <td><a href="https://github.com/ttys3/git-credential-readonly/pull/4/files#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261">+10/-13</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

